### PR TITLE
Adds various production mode bits for real server deployment

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -2,3 +2,9 @@ SOLR_VERSION = 7.7.1
 SOLR_URL: http://127.0.0.1:8983/solr/geoportal-core-development
 BLACKLIGHT_URL: http://localhost:3001
 BLACKLIGHT_JSON_API: http://localhost:3001/admin/api.json
+
+GEOMG_DB_DATABASE: geomg_development
+GEOMG_DB_USER: geomg
+GEOMG_DB_PASSWORD: verysecret
+
+GEOMG_DEVISE_SECRET_KEY: generated-by-rake-secret

--- a/.env.development.example
+++ b/.env.development.example
@@ -8,3 +8,5 @@ GEOMG_DB_USER: geomg
 GEOMG_DB_PASSWORD: verysecret
 
 GEOMG_DEVISE_SECRET_KEY: generated-by-rake-secret
+
+# SECRET_KEY_BASE: set-in-production-mode-if-not-using-credentials-master-key

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config/master.key
 
 # We are only pointing to environment variables in database config
 !config/database.yml
+!config/sidekiq.yml
 !config/webpacker.yml
 
 # dotenv

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ config/master.key
 
 # We are only pointing to environment variables in database config
 !config/database.yml
+!config/webpacker.yml
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ config/master.key
 # We are only pointing to environment variables in database config
 !config/database.yml
 !config/sidekiq.yml
+!config/storage.yml
 !config/webpacker.yml
 
 # dotenv

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ config/master.key
 # config/secrets.yml
 /config/*.yml
 
+# We are only pointing to environment variables in database config
+!config/database.yml
+
 # dotenv
 # TODO Comment out this rule if environment variables can be committed
 .env

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'devise'
 gem 'devise-bootstrap-views', '~> 1.0'
 gem 'devise_invitable', '~> 2.0.0'
 
+gem 'sidekiq', '~> 6.0.7'
+
 # Versioning
 gem 'paper_trail'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
     childprocess (3.0.0)
     cocoon (1.2.14)
     concurrent-ruby (1.1.6)
+    connection_pool (2.2.3)
     content_disposition (1.0.0)
     crass (1.0.6)
     deprecation (1.0.0)
@@ -246,6 +247,8 @@ GEM
       rails (>= 5.0, < 6.1)
       rdf
     rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -283,6 +286,7 @@ GEM
     rdf (3.1.1)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
+    redis (4.2.0)
     regexp_parser (1.7.0)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -319,6 +323,11 @@ GEM
       down (~> 4.4)
       http (>= 3.2, < 5)
       shrine (>= 2.0, < 4)
+    sidekiq (6.0.7)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     simple_form (5.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -420,6 +429,7 @@ DEPENDENCIES
   rails (~> 6.0.2, >= 6.0.2.1)
   sass-rails (>= 6)
   shoulda-context
+  sidekiq (~> 6.0.7)
   simple_form (~> 5.0)
   solr_wrapper (~> 2.1)
   spring

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,15 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  host:     <%= ENV['GEOMG_DB_HOST'] || '127.0.0.1' %>
+  port:     <%= ENV['GEOMG_DB_PORT'] || '5432' %>
+  database: <%= ENV['GEOMG_DB_DATABASE'] %>
+  username: <%= ENV['GEOMG_DB_USER'] %>
+  password: <%= ENV['GEOMG_DB_PASSWORD'] %>
+  pool: 5
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = 'e731cc80f0a8d813c83a708ff8114a82c93ae3212a1e4725356089b7b9d61f0a18cd9c739e344566423c185ed4f8523f95e34040151d2fba75896ddafc2d6df8'
+  config.secret_key = ENV['GEOMG_DEVISE_SECRET_KEY']
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+:concurrency:  3
+:max_retries: 1

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,34 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -1,0 +1,95 @@
+# Note: You must restart bin/webpack-dev-server for changes to take effect
+
+default: &default
+  source_path: app/javascript
+  source_entry_path: packs
+  public_root_path: public
+  public_output_path: packs
+  cache_path: tmp/cache/webpacker
+  check_yarn_integrity: false
+  webpack_compile_output: true
+
+  # Additional paths webpack should lookup modules
+  # ['app/assets', 'engine/foo/app/assets']
+  resolved_paths: ['app/assets']
+
+  # Reload manifest.json on all requests so we reload latest compiled packs
+  cache_manifest: false
+
+  # Extract and emit a css file
+  extract_css: false
+
+  static_assets_extensions:
+    - .jpg
+    - .jpeg
+    - .png
+    - .gif
+    - .tiff
+    - .ico
+    - .svg
+    - .eot
+    - .otf
+    - .ttf
+    - .woff
+    - .woff2
+
+  extensions:
+    - .mjs
+    - .js
+    - .sass
+    - .scss
+    - .css
+    - .module.sass
+    - .module.scss
+    - .module.css
+    - .png
+    - .svg
+    - .gif
+    - .jpeg
+    - .jpg
+
+development:
+  <<: *default
+  compile: true
+
+  # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
+  check_yarn_integrity: true
+
+  # Reference: https://webpack.js.org/configuration/dev-server/
+  dev_server:
+    https: false
+    host: localhost
+    port: 3035
+    public: localhost:3035
+    hmr: false
+    # Inline should be set to true if using HMR
+    inline: true
+    overlay: true
+    compress: true
+    disable_host_check: true
+    use_local_ip: false
+    quiet: false
+    headers:
+      'Access-Control-Allow-Origin': '*'
+    watch_options:
+      ignored: '**/node_modules/**'
+
+
+test:
+  <<: *default
+  compile: true
+
+  # Compile test packs to a separate directory
+  public_output_path: packs-test
+
+production:
+  <<: *default
+
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Extract and emit a css file
+  extract_css: true
+
+  # Cache manifest.json for performance
+  cache_manifest: true

--- a/lib/tasks/geomg/geomg_skidekiq.rake
+++ b/lib/tasks/geomg/geomg_skidekiq.rake
@@ -1,0 +1,44 @@
+# lib/tasks/migrate/users.rake
+require 'sidekiq/api'
+
+namespace :geomg do
+  desc 'Stop sidekiq'
+  task sidekiq_stop: :environment do
+    sh "sudo systemctl stop sidekiq.service || true"
+    sleep(5)
+    sh "sudo systemctl status sidekiq.service || true"
+  end
+
+  task sidekiq_start: :environment do
+    sh "sudo systemctl start sidekiq.service || true"
+    sleep(5)
+    sh "sudo systemctl status sidekiq.service || true"
+  end
+
+  desc 'Check sidekiq stats'
+  task sidekiq_stats: :environment do
+    # Check stats
+    stats = Sidekiq::Stats.new
+    puts stats.inspect
+  end
+
+  desc 'Clear sidekiq queues'
+  task sidekiq_clear_queues: :environment do
+    Sidekiq::RetrySet.new.clear
+    Sidekiq::ScheduledSet.new.clear
+    Sidekiq::Stats.new.reset
+    Sidekiq::DeadSet.new.clear
+
+    stats = Sidekiq::Stats.new
+    stats.queues
+    stats.queues.count
+    stats.queues.clear
+
+    queue = Sidekiq::Queue.new("default")
+    queue.each do |job|
+      job.delete
+    end
+
+    puts stats.inspect
+  end
+end


### PR DESCRIPTION
For the upcoming June sprint:

Much of this is ported from the BTAA Geoportal deployment strategy. All of it should be smoothly integrated into current development strategies, with the addition of some vars to `.env.development`

### Database config
- Adds `config/database.yml` referencing only environment variables to be read from dotenv
- `.env.development.example` with sample env vars for database

### Other secrets
Unknown yet whether or how we would depoy Rails 6 encrypted credentials, but all of that is still operable from env vars. `SECRET_KEY_BASE` example is in `.env.development.example`, and `GEOMG_DEVISE_SECRET_KEY` as well.

### Sidekiq support
- Sidekiq 6 in Gemfile
- `config/sidekiq.yml` no longer gitignored
- Sidekiq Rake tasks ported from Geoportal

### Other files no longer gitignored:
- `config/storage.yml` wanted by Redis
- `config/webpacker.yml` needed by Capistrano when webpacker is invoked on deploy
